### PR TITLE
Alter failure behavior in the case of unrecognized lines

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/domain/Source.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/domain/Source.java
@@ -85,13 +85,14 @@ public final class Source implements JsonObject {
     public void setClassifier(final String classifier) {
         this.classifier = classifier;
     }
-    
+
     public void addCoverage(final int lineNumber, final Integer coverage) {
         int index = lineNumber - 1;
         if (index >= this.coverage.length) {
-            throw new IllegalArgumentException("Line number " + lineNumber + " is greater than the source file " + name + " size");
+            System.err.println("Line number " + lineNumber + " is greater than the source file " + name + " size");
+        } else {
+            this.coverage[lineNumber - 1] = coverage;
         }
-        this.coverage[lineNumber - 1] = coverage;
     }
 
     public Source merge(final Source source) {

--- a/src/test/java/org/eluder/coveralls/maven/plugin/domain/SourceTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/domain/SourceTest.java
@@ -26,10 +26,14 @@ package org.eluder.coveralls.maven.plugin.domain;
  * %[license]
  */
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Ignore;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 public class SourceTest {
 
@@ -41,7 +45,7 @@ public class SourceTest {
         assertArrayEquals(new Integer[] { 3, null, 3, null }, source.getCoverage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddCoverageForSourceOutOfBounds() {
         Source source = new Source("src/main/java/Hello.java", "public class Hello {\n  \n}\n", "E8BD88CF0BDB77A6408234FD91FD22C3");
         source.addCoverage(5, 1);


### PR DESCRIPTION
- Previous behavior would throw an `IllegalArgumentException` when a line outside of the expected range was encountered. This makes sense, but prevents the plugin from operating with non-Java JVM languages that are sometimes forced to include source lines outside the expected range. The example motivating this change is the case of functions that Kotlin inlines, which result in source line numbers that are higher than the number of lines in the source file.
- The new behavior here is to simply log an error to standard error in that event, and not update coverage. This does mean that such unusual lines will not get included properly in coverage, but that seems a better outcome than runtime failure.